### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/templates/player_dashboard.html
+++ b/templates/player_dashboard.html
@@ -961,6 +961,19 @@
         });
         
         // Update dashboard when round advances
+        function escapeHTML(str) {
+            return str.replace(/[&<>"']/g, function (match) {
+                const escapeMap = {
+                    '&': '&amp;',
+                    '<': '&lt;',
+                    '>': '&gt;',
+                    '"': '&quot;',
+                    "'": '&#39;'
+                };
+                return escapeMap[match];
+            });
+        }
+
         socket.on('round_advanced', function(data) {
             console.log('Round advanced to', data.round);
             
@@ -1035,7 +1048,7 @@
                         interestRateElement.dataset.originalValue = originalValue;
                         
                         // Add a calculating indicator
-                        interestRateElement.innerHTML = originalValue + ' <small class="text-muted">(calculating...)</small>';
+                        interestRateElement.innerHTML = escapeHTML(originalValue) + ' <small class="text-muted">(calculating...)</small>';
                     }
                 }
             }


### PR DESCRIPTION
Potential fix for [https://github.com/GitHub-at-Brown/OLG-game/security/code-scanning/7](https://github.com/GitHub-at-Brown/OLG-game/security/code-scanning/7)

To fix the problem, we need to ensure that the text content retrieved from the DOM is properly escaped before being reinserted as HTML. This can be achieved by using a function that escapes HTML special characters. We will create a utility function to escape HTML and use it before setting the `innerHTML`.

1. Create a utility function to escape HTML special characters.
2. Use this function to escape the `originalValue` before concatenating it with the HTML string and setting it to `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
