### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -571,10 +571,10 @@ def reset_game():
             'message': 'Game has been reset to initial state'
         })
     except Exception as e:
-        print(f"Error resetting game: {str(e)}")
+        app.logger.error(f"Error resetting game: {str(e)}")
         return jsonify({
             'success': False,
-            'error': f'Failed to reset game: {str(e)}'
+            'error': 'Failed to reset game due to an internal error.'
         }), 500
 
 @app.route('/api/get_game_state', methods=['GET'])
@@ -602,7 +602,7 @@ def get_game_state():
         return jsonify({'success': True, 'game_state': state})
     except Exception as e:
         app.logger.error(f"Error getting game state: {str(e)}")
-        return jsonify({'success': False, 'message': str(e)})
+        return jsonify({'success': False, 'message': 'Failed to retrieve game state due to an internal error.'})
 
 @socketio.on('connect')
 def handle_connect():


### PR DESCRIPTION
Potential fix for [https://github.com/GitHub-at-Brown/OLG-game/security/code-scanning/5](https://github.com/GitHub-at-Brown/OLG-game/security/code-scanning/5)

To fix the problem, we need to ensure that detailed error information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling in the `reset_game` and `get_game_state` functions.

1. Log the detailed error message using `app.logger.error`.
2. Return a generic error message in the JSON response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
