### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/templates/professor_dashboard.html
+++ b/templates/professor_dashboard.html
@@ -987,7 +987,11 @@
                     topRateElement.dataset.originalText = originalText;
                     
                     // Show calculating indicator
-                    topRateElement.innerHTML = `${originalText} <small class="calculating-indicator">(calculating...)</small>`;
+                    topRateElement.textContent = originalText;
+                    const calculatingIndicator = document.createElement('small');
+                    calculatingIndicator.className = 'calculating-indicator';
+                    calculatingIndicator.textContent = '(calculating...)';
+                    topRateElement.appendChild(calculatingIndicator);
                 }
                 
                 // If the data includes waiting_for, update the waiting list


### PR DESCRIPTION
Potential fix for [https://github.com/GitHub-at-Brown/OLG-game/security/code-scanning/6](https://github.com/GitHub-at-Brown/OLG-game/security/code-scanning/6)

To fix the problem, we need to ensure that any text extracted from the DOM and reinserted as HTML is properly escaped to prevent XSS vulnerabilities. The best way to fix this issue is to use a method that safely inserts text content without interpreting it as HTML. In this case, we can use `textContent` instead of `innerHTML` for the text part and create a new element for the additional HTML content.

1. Extract the original text from the DOM element.
2. Create a new `small` element with the class `calculating-indicator`.
3. Append the `small` element to the `topRateElement` without using `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
