### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -553,7 +553,7 @@ def advance_round():
     except Exception as e:
         app.logger.error(f"Error advancing round: {str(e)}")
         app.logger.exception("Exception during round advancement:")
-        return jsonify({'success': False, 'error': str(e)}), 500
+        return jsonify({'success': False, 'error': 'An internal error has occurred.'}), 500
 
 @app.route('/api/reset_game', methods=['POST'])
 def reset_game():
@@ -572,6 +572,7 @@ def reset_game():
         })
     except Exception as e:
         app.logger.error(f"Error resetting game: {str(e)}")
+        app.logger.exception("Exception during game reset:")
         return jsonify({
             'success': False,
             'error': 'Failed to reset game due to an internal error.'
@@ -602,6 +603,7 @@ def get_game_state():
         return jsonify({'success': True, 'game_state': state})
     except Exception as e:
         app.logger.error(f"Error getting game state: {str(e)}")
+        app.logger.exception("Exception during game state retrieval:")
         return jsonify({'success': False, 'message': 'Failed to retrieve game state due to an internal error.'})
 
 @socketio.on('connect')


### PR DESCRIPTION
Potential fix for [https://github.com/GitHub-at-Brown/OLG-game/security/code-scanning/3](https://github.com/GitHub-at-Brown/OLG-game/security/code-scanning/3)

To fix the problem, we should replace the detailed error message returned to the user with a generic error message. The detailed error information should be logged on the server for debugging purposes. This approach ensures that sensitive information is not exposed to the user while still allowing developers to diagnose issues.

Specifically, we need to:
1. Replace the detailed error message in the JSON response with a generic message.
2. Ensure that the detailed error information is logged using `app.logger`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
