### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -246,7 +246,7 @@ def add_test_players():
     except Exception as e:
         app.logger.error(f"Error adding test users: {str(e)}")
         # Consider more specific error handling/logging
-        return jsonify({'success': False, 'error': f'Failed to add test users: {str(e)}'}), 500
+        return jsonify({'success': False, 'error': 'Failed to add test users due to an internal error'}), 500
 
 @app.route('/api/set_policy', methods=['POST'])
 def set_policy():
@@ -400,7 +400,7 @@ def set_policy():
     except Exception as e:
         app.logger.error(f"Error setting policy: {str(e)}")
         app.logger.exception("Full traceback:")
-        return jsonify({'success': False, 'message': str(e)})
+        return jsonify({'success': False, 'message': 'Failed to set policy due to an internal error'})
 
 @app.route('/api/advance_round', methods=['POST'])
 def advance_round():


### PR DESCRIPTION
Potential fix for [https://github.com/GitHub-at-Brown/OLG-game/security/code-scanning/1](https://github.com/GitHub-at-Brown/OLG-game/security/code-scanning/1)

To fix the problem, we need to ensure that the detailed exception message is not exposed to the client. Instead, we should log the detailed error message on the server side and return a generic error message to the client. This can be achieved by modifying the exception handling block to log the error and return a generic message.

**Steps to fix:**
1. Modify the exception handling block in the `add_test_players` function to log the detailed error message.
2. Return a generic error message to the client.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
